### PR TITLE
FFWEB-2207:Fix trigger import for 7.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## Unreleased
+### Fixed
+- Import
+    - Standard adapter does not use query parameters
+
 ## [v0.9.1] - 2021.04.07
 ### Fixed
 - Import

--- a/src/Resource/Standard/ImportAdapter.php
+++ b/src/Resource/Standard/ImportAdapter.php
@@ -21,7 +21,7 @@ class ImportAdapter implements Import
     public function import(string $channel, string $type, array $params = []): array
     {
         $params = ['channel' => $channel, 'type' => ['search' => 'data'][$type] ?? $type, 'format' => 'json'] + $params;
-        $resp   = $this->client->request('GET', 'Import.ff', $params);
+        $resp   = $this->client->request('GET', 'Import.ff', ['query' => $params]);
         return json_decode((string) $resp->getBody(), true);
     }
 


### PR DESCRIPTION
- Description: 
Import.ff does not pass channel as well as the other parameters as a query string. In result FACT-Finder trigger import on every channel in given instance.
- Tested with PHP version(s): 
7.4
- Tested with FACT-Finder® version(s): 
7.3
