### PR TITLE
FFWEB-2565 - increase api version from v4 to v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Change
+- increase api version from v4 to v5
+
 ## [v0.9.3] - 2021.11.04
 ### Changed
  Compatibility

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": ">=7.1||~8.1.0",
+    "php": ">=7.1",
     "ext-json": "*",
     "guzzlehttp/guzzle": "^6.3|^7.0",
     "psr/http-client": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.1||~8.1.0",
     "ext-json": "*",
     "guzzlehttp/guzzle": "^6.3|^7.0",
     "psr/http-client": "^1.0",

--- a/src/Resource/NG/ImportAdapter.php
+++ b/src/Resource/NG/ImportAdapter.php
@@ -20,13 +20,13 @@ class ImportAdapter implements Import
     public function import(string $channel, string $type, array $params = []): array
     {
         $params   = ['channel' => $channel] + $params;
-        $response = $this->client->request('POST', "rest/v4/import/{$type}", ['query' => $params]);
+        $response = $this->client->request('POST', "rest/v5/import/{$type}", ['query' => $params]);
         return (array) json_decode((string) $response->getBody(), true);
     }
 
     public function running(string $channel): bool
     {
-        $response = $this->client->request('GET', 'rest/v4/import/running', ['query' => ['channel' => $channel]]);
+        $response = $this->client->request('GET', 'rest/v5/import/running', ['query' => ['channel' => $channel]]);
         return (bool) json_decode((string) $response->getBody(), true);
     }
 }

--- a/src/Resource/NG/SearchAdapter.php
+++ b/src/Resource/NG/SearchAdapter.php
@@ -20,14 +20,14 @@ class SearchAdapter implements Search
     public function search(string $channel, string $query, array $params = []): array
     {
         $params   = ['query' => $query] + $params;
-        $response = $this->client->request('GET', "rest/v4/search/{$channel}", ['query' => $params]);
+        $response = $this->client->request('GET', "rest/v5/search/{$channel}", ['query' => $params]);
         return (array) json_decode((string) $response->getBody(), true);
     }
 
     public function suggest(string $channel, string $query, array $params = []): array
     {
         $params   = ['query' => $query] + $params;
-        $response = $this->client->request('GET', "rest/v4/suggest/{$channel}", ['query' => $params]);
+        $response = $this->client->request('GET', "rest/v5/suggest/{$channel}", ['query' => $params]);
         return (array) json_decode((string) $response->getBody(), true);
     }
 }

--- a/src/Resource/NG/TrackingAdapter.php
+++ b/src/Resource/NG/TrackingAdapter.php
@@ -20,7 +20,7 @@ class TrackingAdapter implements Tracking
     public function track(string $channel, string $event, array $eventData = []): array
     {
         $params   = ['body' => json_encode($eventData), 'headers' => ['Content-Type' => 'application/json']];
-        $response = $this->client->request('POST', "rest/v4/track/{$channel}/{$event}", $params);
+        $response = $this->client->request('POST', "rest/v5/track/{$channel}/{$event}", $params);
         return json_decode((string) $response->getBody(), true) ?? [];
     }
 }


### PR DESCRIPTION
 - Fixes:
   - FFWEB-2565 
- Description: 
  - increase api version from v4 to v5
- Tested with PHP version(s): 
  - 7.4 | 8.1
- Tested with FACT-Finder® version(s): 
  - 7.3
