### PR TITLE
FFWEB-2652: Extend Search interface by records method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+SearchAdapter
+- Extend Search interface by records method
+
 ## [v0.9.5] - 2022.12.05
 ### Add
  AdapterFactory

--- a/src/Resource/NG/SearchAdapter.php
+++ b/src/Resource/NG/SearchAdapter.php
@@ -39,6 +39,14 @@ class SearchAdapter implements Search
         return (array) json_decode((string) $response->getBody(), true);
     }
 
+    public function records(string $channel, string $query, array $params = []): array
+    {
+        $params     = ['query' => $query] + $params;
+        $apiVersion = $this->getApiVersion();
+        $response   = $this->client->request('GET', "rest/{$apiVersion}/records/{$channel}", ['query' => $params]);
+        return (array) json_decode((string) $response->getBody(), true);
+    }
+
     private function getApiVersion(): string
     {
         return (string) $this->config['api_version'] ?? 'v4';

--- a/src/Resource/Search.php
+++ b/src/Resource/Search.php
@@ -27,4 +27,14 @@ interface Search
      * @throws ClientExceptionInterface
      */
     public function suggest(string $channel, string $query, array $params = []): array;
+
+    /**
+     * @param string $channel
+     * @param string $query
+     * @param array  $params
+     *
+     * @return array
+     * @throws ClientExceptionInterface
+     */
+    public function records(string $channel, string $query, array $params = []): array;
 }

--- a/src/Resource/Standard/SearchAdapter.php
+++ b/src/Resource/Standard/SearchAdapter.php
@@ -30,4 +30,11 @@ class SearchAdapter implements Search
         $response = $this->client->request('GET', 'Suggest.ff', ['query' => $params]);
         return json_decode((string) $response->getBody(), true);
     }
+
+    public function records(string $channel, string $query, array $params = []): array
+    {
+        $params   = ['query' => $query, 'channel' => $channel, 'format' => 'json'] + $params;
+        $response = $this->client->request('GET', 'Records.ff', ['query' => $params]);
+        return json_decode((string) $response->getBody(), true);
+    }
 }


### PR DESCRIPTION
- Closes
  - FFWEB-2652
- Description: 
  - extend `Search interface` by `records` method
- Tested with PHP version(s): 
  - 7.4
- Tested with FACT-Finder® version(s): 
  - NG
