### PR TITLE
FFWEB-2776 Declare psr/log v3.0 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## Unreleased
+### Changed
+Compatibility
+- Declare psr/log v3.0 compatibility
+
 ## [v0.9.6] - 2023.01.24
 SearchAdapter
 - Extend Search interface by records method

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ handled by an HTTP client which is PSR-18 compatible. Behind the scenes, we use
 GuzzleHTTP, a de-facto industry standard library for HTTP communication.
 
 ## Requirements
-- PHP 7.x
+- PHP 7.x or 8.1.x
 - FACT-Finder® 7.x or FACT-Finder® NG
 
 ## License

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "ext-json": "*",
     "guzzlehttp/guzzle": "^6.3|^7.0",
     "psr/http-client": "^1.0",
-    "psr/log": "^1.1"
+    "psr/log": "^1.1||^3.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.17",


### PR DESCRIPTION
- Closes #FFWEB-2776
- Description:  Declare psr/log v3.0 compatibility
- Tested with PHP version(s): 8.1
- Tested with FACT-Finder® version(s): NG
