### PR TITLE
FFWEB-2960: Declare PHP8.2 and PHP8.3 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+### Unreleased
+### Changed
+Compatibility
+- Declare PHP8.2 and PHP8.3 compatibility
+
 ## [v0.9.7] - 2023.07.31
 ### Changed
 Compatibility

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ handled by an HTTP client which is PSR-18 compatible. Behind the scenes, we use
 GuzzleHTTP, a de-facto industry standard library for HTTP communication.
 
 ## Requirements
-- PHP 7.x or 8.1.x
+- PHP 7.x or 8.x
 - FACT-Finder® 7.x or FACT-Finder® NG
 
 ## License

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": ">=7.1||~8.1.0",
+    "php": ">=7.1||~8.1",
     "ext-json": "*",
     "guzzlehttp/guzzle": "^6.3|^7.0",
     "psr/http-client": "^1.0",


### PR DESCRIPTION
- Closes #FFWEB-2960
- Description: Declare PHP8.2 and PHP8.3 compatibility
- Tested with PHP version(s): 8.1, 8.2
- Tested with FACT-Finder® version(s): n/a
