### PR TITLE
FFWEB-3207: Remove timeout because of import request duration

### DIFF
--- a/src/Client/ClientBuilder.php
+++ b/src/Client/ClientBuilder.php
@@ -62,7 +62,6 @@ class ClientBuilder
             'base_uri'    => $this->serverUrl,
             'handler'     => $handler,
             'headers'     => ['Accept' => 'application/json'],
-            'timeout'     => 10,
             'http_errors' => false,
         ];
 


### PR DESCRIPTION
- Closes FFWEB-3207
- Description: Import request could be quite long for some customers. That's why set timeout is problematic.
- Tested with PHP version(s): 8.1
- Tested with FACT-Finder® version(s): NG
